### PR TITLE
Add clone for trait when the encapsulated struct supports it

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -5,6 +5,15 @@ pub enum StringOrStruct<S> {
     Struct(S),
 }
 
+impl<S: Clone> Clone for StringOrStruct<S> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::String(as_string) => Self::String(as_string.clone()),
+            Self::Struct(as_struct) => Self::Struct(as_struct.clone()),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub enum StringOrStructOrVec<S, V> {
     String(String),
@@ -12,8 +21,27 @@ pub enum StringOrStructOrVec<S, V> {
     Vec(V),
 }
 
+impl<S: Clone, V: Clone> Clone for StringOrStructOrVec<S, V> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::String(as_string) => Self::String(as_string.clone()),
+            Self::Struct(as_struct) => Self::Struct(as_struct.clone()),
+            Self::Vec(as_vec) => Self::Vec(as_vec.clone()),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub enum SingleOrVec<S> {
     Single(S),
     Vec(Vec<S>)
+}
+
+impl<S: Clone> Clone for SingleOrVec<S> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Single(as_single) => Self::Single(as_single.clone()),
+            Self::Vec(as_vec) => Self::Vec(as_vec.clone()),
+        }
+    }
 }


### PR DESCRIPTION
This implements the clone trait when the encapsulated struct implements the clone trait

This should not effect existing code but allow others todo things like 

```
#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
struct StructUsedBySerde {
    value: StringOrStruct<ThingThatCanBeCloned>,
}
```

The change only has a effect when the encapsulated struct does implement Clone and does not force the encapsulated struct to impl Clone. For cases were the encapsulated struct does not implement Clone there should be no effect.

This PR resolves #3 